### PR TITLE
Upgrade build to dual CJS/ESM bundles & add React 19 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mirawision/usa-map-react",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mirawision/usa-map-react",
-      "version": "1.0.2",
+      "version": "1.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -18,8 +18,8 @@
         "webpack-cli": "5.1.4"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirawision/usa-map-react",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "A highly customizable and interactive USA map component for React, allowing easy integration, state-based customization, and interactivity for data visualization and user interaction.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "webpack",
+    "prepare": "npm run build",
     "start": "npm run build && node dist/index.js",
     "pack": "npm pack",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   },
   "homepage": "https://mirawision.github.io/usa-map-react",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/react": "18.3.3",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "@mirawision/usa-map-react",
   "version": "1.0.6",
   "description": "A highly customizable and interactive USA map component for React, allowing easy integration, state-based customization, and interactivity for data visualization and user interaction.",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
@@ -42,8 +44,8 @@
   },
   "homepage": "https://mirawision.github.io/usa-map-react",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/react": "18.3.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,17 +1,9 @@
+// webpack.config.js
 const path = require('path');
 const webpack = require('webpack');
 
-module.exports = {
+const base = {
   entry: './src/index.ts',
-  mode: 'production',
-  output: {
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist'),
-    library: 'USAMap',
-    libraryTarget: 'umd',
-    globalObject: 'this',
-    umdNamedDefine: true,
-  },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
   },
@@ -28,23 +20,40 @@ module.exports = {
       },
     ],
   },
+  externals: ['react', 'react-dom'],
+  optimization: {
+    concatenateModules: false,
+  },
   plugins: [
     new webpack.DefinePlugin({
-      'self': 'typeof self !== "undefined" ? self : this',
+      self: 'typeof self !== "undefined" ? self : this',
     }),
   ],
-  externals: {
-    react: {
-      commonjs: 'react',
-      commonjs2: 'react',
-      amd: 'react',
-      root: 'React',
-    },
-    'react-dom': {
-      commonjs: 'react-dom',
-      commonjs2: 'react-dom',
-      amd: 'react-dom',
-      root: 'ReactDOM',
+};
+
+module.exports = [
+  // 1) CommonJS build
+  {
+    ...base,
+    mode: 'production',
+    externalsType: 'commonjs2',
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'index.cjs.js',
+      library: { type: 'commonjs2' },
     },
   },
-};
+
+  // 2) ESModule build
+  {
+    ...base,
+    mode: 'production',
+    externalsType: 'module',
+    experiments: { outputModule: true },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'index.esm.js',
+      library: { type: 'module' },
+    },
+  },
+];


### PR DESCRIPTION
## Why

- Support React 19 (and still React 18) as peer dependencies  
- Produce both CommonJS and ESModule bundles for broader compatibility  
- Simplify externals so you don’t accidentally bundle React/ReactDOM  

## What Changed

1. **Version bumped** to 2.0.0  
2. **peerDependencies** updated to:
   ```json
   "react": "^18.0.0 || ^19.0.0",
   "react-dom": "^18.0.0 || ^19.0.0"
